### PR TITLE
Dockerfile.buildroot: Add the `expect` package

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,6 +1,7 @@
 FROM ghcr.io/%%GITHUB_OWNER%%/retro-toolchain/base
 
 RUN apt update && apt install -y \
+    expect \
     file \
     wget \
     cpio \


### PR DESCRIPTION
This package provides the `unbuffer` binary, which `utils/brmake` depends on.